### PR TITLE
🔧 update: move to node.js as runtime engine

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: oven-sh/setup-bun@v2
       - uses: actions/setup-node@v4
         with:
-          node-version: '26'
+          node-version: '25'
       - uses: wgtechlabs/package-build-flow-action@v2.0.1
         with:
           npm-token: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: oven-sh/setup-bun@v2
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '26'
       - uses: wgtechlabs/package-build-flow-action@v2.0.1
         with:
           npm-token: ${{ secrets.NPM_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thanks for your interest in contributing to **GitHub Labels Template**! Here's h
 
 ## Prerequisites
 
-- [Node.js](https://nodejs.org) (latest)
+- [Node.js](https://nodejs.org) (v25+)
 - [Bun](https://bun.sh) (v1.0+)
 - [GitHub CLI](https://cli.github.com) (`gh`) installed and authenticated
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,7 @@ Thanks for your interest in contributing to **GitHub Labels Template**! Here's h
 
 ## Prerequisites
 
+- [Node.js](https://nodejs.org) (latest)
 - [Bun](https://bun.sh) (v1.0+)
 - [GitHub CLI](https://cli.github.com) (`gh`) installed and authenticated
 
@@ -19,7 +20,8 @@ bun install
 
 ```bash
 # Run the CLI locally
-bun src/index.ts apply --help
+bun run build
+node dist/index.js apply --help
 
 # Build for production
 bun run build

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ A CLI tool to apply a curated set of GitHub labels to any repository using `gh` 
 - 📊 **Clear Output**: Structured logging powered by [@wgtechlabs/log-engine](https://github.com/wgtechlabs/log-engine) with color-coded levels and emoji
 - 🎨 **ASCII Banner**: Beautiful ANSI Shadow figlet banner with version and author info
 - 🤖 **AI Label Generator**: Generate custom labels using GitHub Copilot — interactive pick, refine, and apply
-- 🌐 **Dual Runtime**: Works with both `npx` and `bunx`
+- 🌐 **Node Runtime + Bun Toolchain**: Runs on Node.js, built and tested with Bun
 
 ## Quick Start
 
@@ -325,6 +325,8 @@ OPTIONS (preview)
 ## Testing
 
 This project uses the [Bun test framework](https://bun.sh/docs/cli/test) for testing.
+
+Runtime execution uses Node.js (latest recommended).
 
 ```bash
 # Run all tests

--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ A CLI tool to apply a curated set of GitHub labels to any repository using `gh` 
 # Using npx
 npx github-labels-template apply
 
-# Using bunx
-bunx github-labels-template apply
+# Using npm exec
+npm exec github-labels-template apply
 ```
 
 That's it. All 23 labels are applied to the current repo.

--- a/bun.lock
+++ b/bun.lock
@@ -15,6 +15,7 @@
       "devDependencies": {
         "@types/bun": "latest",
         "@types/figlet": "^1.7.0",
+        "@types/node": "latest",
       },
     },
   },
@@ -71,7 +72,7 @@
 
     "@types/figlet": ["@types/figlet@1.7.0", "", {}, "sha512-KwrT7p/8Eo3Op/HBSIwGXOsTZKYiM9NpWRBJ5sVjWP/SmlS+oxxRvJht/FNAtliJvja44N3ul1yATgohnVBV0Q=="],
 
-    "@types/node": ["@types/node@25.3.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-4K3bqJpXpqfg2XKGK9bpDTc6xO/xoUP/RBWS7AtRMug6zZFaRekiLzjVtAoZMquxoAbzBvy5nxQ7veS5eYzf8A=="],
+    "@types/node": ["@types/node@25.7.0", "", { "dependencies": { "undici-types": "~7.21.0" } }, "sha512-z+pdZyxE+RTQE9AcboAZCb4otwcrvgHD+GlBpPgn0emDVt0ohrTMhAwlr2Wd9nZ+nihhYFxO2pThz3C5qSu2Eg=="],
 
     "@wgtechlabs/log-engine": ["@wgtechlabs/log-engine@2.3.1", "", {}, "sha512-qYwGef4KjcWpFvfC/e6uum/Q2ICTJbaXBZf+qCDmho1rNZ/umqyeDH3Cvk86e2Jy5TkDFPA+rOcTkmrM1rGKkw=="],
 
@@ -105,10 +106,14 @@
 
     "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
-    "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
+    "undici-types": ["undici-types@7.21.0", "", {}, "sha512-w9IMgQrz4O0YN1LtB7K5P63vhlIOvC7opSmouCJ+ZywlPAlO9gIkJ+otk6LvGpAs2wg4econaCz3TvQ9xPoyuQ=="],
 
     "vscode-jsonrpc": ["vscode-jsonrpc@8.2.1", "", {}, "sha512-kdjOSJ2lLIn7r1rtrMbbNCHjyMPfRnowdKjBQ+mGq6NAW5QY2bEZC/khaC5OR8svbbjvLEaIXkOq45e2X9BIbQ=="],
 
     "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
+
+    "bun-types/@types/node": ["@types/node@25.3.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-4K3bqJpXpqfg2XKGK9bpDTc6xO/xoUP/RBWS7AtRMug6zZFaRekiLzjVtAoZMquxoAbzBvy5nxQ7veS5eYzf8A=="],
+
+    "bun-types/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
   }
 }

--- a/bun.lock
+++ b/bun.lock
@@ -15,7 +15,7 @@
       "devDependencies": {
         "@types/bun": "latest",
         "@types/figlet": "^1.7.0",
-        "@types/node": "latest",
+        "@types/node": "^25.7.0",
       },
     },
   },

--- a/package.json
+++ b/package.json
@@ -11,12 +11,13 @@
   ],
   "scripts": {
     "build": "bun build src/index.ts --outfile dist/index.js --target node --packages external",
-    "dev": "bun src/index.ts",
-    "preview": "bun src/index.ts preview",
+    "dev": "bun run build && node dist/index.js",
+    "preview": "bun run build && node dist/index.js preview",
+    "start": "node dist/index.js",
     "test": "bun test"
   },
   "engines": {
-    "node": ">=18",
+    "node": ">=26",
     "bun": ">=1.0"
   },
   "keywords": [
@@ -41,6 +42,7 @@
     "picocolors": "^1.1.1"
   },
   "devDependencies": {
+    "@types/node": "latest",
     "@types/bun": "latest",
     "@types/figlet": "^1.7.0"
   }

--- a/package.json
+++ b/package.json
@@ -13,11 +13,11 @@
     "build": "bun build src/index.ts --outfile dist/index.js --target node --packages external",
     "dev": "bun run build && node dist/index.js",
     "preview": "bun run build && node dist/index.js preview",
-    "start": "node dist/index.js",
+    "start": "bun run build && node dist/index.js",
     "test": "bun test"
   },
   "engines": {
-    "node": ">=26",
+    "node": ">=25",
     "bun": ">=1.0"
   },
   "keywords": [
@@ -42,7 +42,7 @@
     "picocolors": "^1.1.1"
   },
   "devDependencies": {
-    "@types/node": "latest",
+    "@types/node": "^25.7.0",
     "@types/bun": "latest",
     "@types/figlet": "^1.7.0"
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "ESNext",
     "module": "ESNext",
     "moduleResolution": "bundler",
-    "types": ["bun-types"],
+    "types": ["node", "bun-types"],
     "resolveJsonModule": true,
     "strict": true,
     "skipLibCheck": true,


### PR DESCRIPTION
This pull request updates the project to use the latest Node.js runtime (v26+) and adjusts documentation, scripts, and configurations to clarify that the toolchain uses Bun for building and Node.js for execution. It also updates development scripts for a more standard workflow and improves type safety in development.

**Runtime and Toolchain Updates**
* Updated the Node.js version in `.github/workflows/package.yml` and `package.json` to `26` or higher, ensuring all builds and executions use the latest Node.js runtime. [[1]](diffhunk://#diff-170ebc8e4dc40acf23cbe0ecce5f3e2aef1652511f59860db704106b197e1d52L22-R22) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L14-R20)
* Updated documentation in `README.md` and `CONTRIBUTING.md` to clarify that the tool is built with Bun but runs on Node.js, replacing references to dual runtime (`npx`/`bunx`) with the new approach. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L22-R22) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R287-R288) [[3]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055R7)

**Development Workflow Improvements**
* Modified `package.json` scripts so that `dev`, `preview`, and `start` commands build with Bun and execute with Node.js, providing a more consistent and reliable development experience.
* Updated usage instructions in `CONTRIBUTING.md` to reflect the new build and run steps using Node.js after building with Bun.

**Type Safety Enhancements**
* Added `@types/node` as a development dependency to improve type safety and editor support when working with Node.js APIs.